### PR TITLE
Fix to look up case-insensitive reference link

### DIFF
--- a/src/main/java/io/github/gitbucket/markedj/InlineLexer.java
+++ b/src/main/java/io/github/gitbucket/markedj/InlineLexer.java
@@ -118,7 +118,7 @@ public class InlineLexer {
                     } else {
                         key = cap.get(1).replaceAll("\\s+", "");
                     }
-                    Lexer.Link link = links.get(key);
+                    Lexer.Link link = links.get(key.toLowerCase());
                     if(link == null || isEmpty(link.getHref())){
                         out.append(renderer.nolink(cap.get(0)));
                         continue;

--- a/src/test/java/io/github/gitbucket/markedj/MarkedTest.java
+++ b/src/test/java/io/github/gitbucket/markedj/MarkedTest.java
@@ -46,6 +46,12 @@ public class MarkedTest {
     }
 
     @Test
+    public void testReflink() throws Exception {
+      String result = Marked.marked("[FOO], [bar][Foo], [Bar]\n\n[Foo]: http://example.com");
+      assertEquals("<p><a href=\"http://example.com\">FOO</a>, <a href=\"http://example.com\">bar</a>, [Bar]</p>\n", result);
+    }
+
+    @Test
     public void testEm() throws Exception {
         {
             String result = Marked.marked("_aa__a__aa_", new Options());


### PR DESCRIPTION
Current markedj converts the key of link definition to lower case, but it dosen't convert the key of reference link. It causes the key not to look up. See following Markdown:

```markdown
[Foo]

[Foo]: http://example.com
```

It yields to `<p>[Foo]</p>`, but the result we expected is `<p><a href="http://example.com">Foo</a></p>` because the key `Foo` can't be looked up.

I fixed the key of reference link is converted to lower case when looking it up from definitions.