### PR TITLE
add hard line break when backslash at EOL

### DIFF
--- a/src/main/java/io/github/gitbucket/markedj/Grammer.java
+++ b/src/main/java/io/github/gitbucket/markedj/Grammer.java
@@ -77,7 +77,7 @@ public class Grammer {
 
     public static String INLINE_ESCAPE = "^\\\\([\\\\`*{}\\[\\]()#+\\-.!_>])";
     public static String INLINE_TEXT   = "^[\\s\\S]+?(?=[\\\\<!\\[_*`]| {2,}\\n|$)";
-    public static String INLINE_BR     = "^ {2,}\\n(?!\\s*$)";
+    public static String INLINE_BR     = "^( {2,}|\\\\)\\n(?!\\s*$)";
 
     static {
         INLINE_RULES.put("escape", new FindFirstRule(INLINE_ESCAPE));

--- a/src/test/java/io/github/gitbucket/markedj/MarkedTest.java
+++ b/src/test/java/io/github/gitbucket/markedj/MarkedTest.java
@@ -264,4 +264,20 @@ public class MarkedTest {
             in.close();
         }
     }
+
+    @Test
+    public void testHardLineBreakWithSpaces() {
+        String result = Marked.marked("Line 1  \n" +
+                "Line 2");
+        assertEquals("<p>Line 1<br>\n" +
+                " Line 2</p>", result);
+    }
+
+    @Test
+    public void testHardLineBreakWithBackslash() {
+        String result = Marked.marked("Line 1\\\n" +
+                "Line 2");
+        assertEquals("<p>Line 1<br>\n" +
+                " Line 2</p>", result);
+    }
 }


### PR DESCRIPTION
after https://github.com/markedjs/marked/commit/47cf2b2c:
A backslash at the end of the line is a hard line break.

Ref: https://spec.commonmark.org/0.28/#example-293